### PR TITLE
Hotfix/google oauth

### DIFF
--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -9,8 +9,10 @@ https://docs.djangoproject.com/en/2.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
-
 import os
+import environ
+env = environ.Env()
+environ.Env.read_env()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -27,7 +29,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
-SITE_ID = 3
+SITE_ID = int(env('SITE_ID'))
 
 # Application definition
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ urllib3==1.26.18
 wsproto==1.2.0
 django-allauth
 django-sslserver
+django-environ


### PR DESCRIPTION
Ya está arreglado el tema del SITE_ID con google para que todos podamos usar uno distinto. Para esto usamos django-environ, lo he añadido al requirements.txt teneis que crearos un .env dentro de decide/decide (es decir, la misma carpeta que settings.py) y ahí definis vuestro SITE_ID por ejemplo el mio es el 3 entonces lo pongo así:
A parte de esto todo debería ir bien, si veis algo raro me lo decís :)

![imagen](https://github.com/3ralon/decide-single-zambrano/assets/73229438/c9b0aa32-1f63-4f3b-858d-1915b3183825)
