### PR TITLE
fix: soluciona fallos en tests de voting

### DIFF
--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -25,7 +25,6 @@ from datetime import datetime
 
 
 class VotingTestCase(BaseTestCase):
-
     def setUp(self):
         super().setUp()
 
@@ -40,16 +39,17 @@ class VotingTestCase(BaseTestCase):
         return k.encrypt(msg)
 
     def create_voting(self):
-        q = Question(desc='test question')
+        q = Question(desc="test question")
         q.save()
         for i in range(5):
-            opt = QuestionOption(question=q, option='option {}'.format(i+1))
+            opt = QuestionOption(question=q, option="option {}".format(i + 1))
             opt.save()
-        v = Voting(name='test voting', question=q)
+        v = Voting(name="test voting", question=q)
         v.save()
 
-        a, _ = Auth.objects.get_or_create(url=settings.BASEURL,
-                                          defaults={'me': True, 'name': 'test auth'})
+        a, _ = Auth.objects.get_or_create(
+            url=settings.BASEURL, defaults={"me": True, "name": "test auth"}
+        )
         a.save()
         v.auths.add(a)
 
@@ -57,7 +57,7 @@ class VotingTestCase(BaseTestCase):
 
     def create_voters(self, v):
         for i in range(100):
-            u, _ = User.objects.get_or_create(username='testvoter{}'.format(i))
+            u, _ = User.objects.get_or_create(username="testvoter{}".format(i))
             u.is_active = True
             u.save()
             c = Census(voter_id=u.id, voting_id=v.id)
@@ -65,8 +65,8 @@ class VotingTestCase(BaseTestCase):
 
     def get_or_create_user(self, pk):
         user, _ = User.objects.get_or_create(pk=pk)
-        user.username = 'user{}'.format(pk)
-        user.set_password('qwerty')
+        user.username = "user{}".format(pk)
+        user.set_password("qwerty")
         user.save()
         return user
 
@@ -80,18 +80,18 @@ class VotingTestCase(BaseTestCase):
             for i in range(random.randint(0, 5)):
                 a, b = self.encrypt_msg(opt.number, v)
                 data = {
-                    'voting': v.id,
-                    'voter': voter.voter_id,
-                    'vote': { 'a': a, 'b': b },
+                    "voting": v.id,
+                    "voter": voter.voter_id,
+                    "vote": {"a": a, "b": b},
                 }
                 clear[opt.number] += 1
                 user = self.get_or_create_user(voter.voter_id)
                 self.login(user=user.username)
                 voter = voters.pop()
-                mods.post('store', json=data)
+                mods.post("store", json=data)
         return clear
 
-    '''def test_complete_voting(self):
+    """def test_complete_voting(self):
         v = self.create_voting()
         self.create_voters(v)
 
@@ -112,141 +112,144 @@ class VotingTestCase(BaseTestCase):
             self.assertEqual(tally.get(q.number, 0), clear.get(q.number, 0))
 
         for q in v.postproc:
-            self.assertEqual(tally.get(q["number"], 0), q["votes"])'''
+            self.assertEqual(tally.get(q["number"], 0), q["votes"])"""
 
     def test_create_voting_from_api(self):
-        data = {'name': 'Example'}
-        response = self.client.post('/voting/', data, format='json')
+        data = {"name": "Example"}
+        response = self.client.post("/voting/", data, format="json")
         self.assertEqual(response.status_code, 401)
 
         # login with user no admin
-        self.login(user='noadmin')
-        response = mods.post('voting', params=data, response=True)
+        self.login(user="noadmin")
+        response = mods.post("voting", params=data, response=True)
         self.assertEqual(response.status_code, 403)
 
         # login with user admin
         self.login()
-        response = mods.post('voting', params=data, response=True)
+        response = mods.post("voting", params=data, response=True)
         self.assertEqual(response.status_code, 400)
 
         data = {
-            'name': 'Example',
-            'desc': 'Description example',
-            'question': 'I want a ',
-            'question_opt': ['cat', 'dog', 'horse']
+            "name": "Example",
+            "desc": "Description example",
+            "question": "I want a ",
+            "question_type": "DEFAULT",
+            "question_opt": ["cat", "dog", "horse"],
         }
 
-        response = self.client.post('/voting/', data, format='json')
+        response = self.client.post("/voting/", data, format="json")
         self.assertEqual(response.status_code, 201)
 
     def test_update_voting(self):
         voting = self.create_voting()
 
-        data = {'action': 'start'}
-        #response = self.client.post('/voting/{}/'.format(voting.pk), data, format='json')
-        #self.assertEqual(response.status_code, 401)
+        data = {"action": "start"}
+        # response = self.client.post('/voting/{}/'.format(voting.pk), data, format='json')
+        # self.assertEqual(response.status_code, 401)
 
         # login with user no admin
-        self.login(user='noadmin')
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        self.login(user="noadmin")
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 403)
 
         # login with user admin
         self.login()
-        data = {'action': 'bad'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "bad"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 400)
 
         # STATUS VOTING: not started
-        for action in ['stop', 'tally']:
-            data = {'action': action}
-            response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        for action in ["stop", "tally"]:
+            data = {"action": action}
+            response = self.client.put(
+                "/voting/{}/".format(voting.pk), data, format="json"
+            )
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.json(), 'Voting is not started')
+            self.assertEqual(response.json(), "Voting is not started")
 
-        data = {'action': 'start'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "start"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), 'Voting started')
+        self.assertEqual(response.json(), "Voting started")
 
         # STATUS VOTING: started
-        data = {'action': 'start'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "start"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), 'Voting already started')
+        self.assertEqual(response.json(), "Voting already started")
 
-        data = {'action': 'tally'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "tally"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), 'Voting is not stopped')
+        self.assertEqual(response.json(), "Voting is not stopped")
 
-        data = {'action': 'stop'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "stop"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), 'Voting stopped')
+        self.assertEqual(response.json(), "Voting stopped")
 
         # STATUS VOTING: stopped
-        data = {'action': 'start'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "start"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), 'Voting already started')
+        self.assertEqual(response.json(), "Voting already started")
 
-        data = {'action': 'stop'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "stop"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), 'Voting already stopped')
+        self.assertEqual(response.json(), "Voting already stopped")
 
-        data = {'action': 'tally'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "tally"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), 'Voting tallied')
+        self.assertEqual(response.json(), "Voting tallied")
 
         # STATUS VOTING: tallied
-        data = {'action': 'start'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "start"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), 'Voting already started')
+        self.assertEqual(response.json(), "Voting already started")
 
-        data = {'action': 'stop'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "stop"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), 'Voting already stopped')
+        self.assertEqual(response.json(), "Voting already stopped")
 
-        data = {'action': 'tally'}
-        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        data = {"action": "tally"}
+        response = self.client.put("/voting/{}/".format(voting.pk), data, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), 'Voting already tallied')
-        
+        self.assertEqual(response.json(), "Voting already tallied")
+
     def test_to_string(self):
-        #Crea un objeto votacion
+        # Crea un objeto votacion
         v = self.create_voting()
-        #Verifica que el nombre de la votacion es test voting
-        self.assertEquals(str(v),"test voting")
-        #Verifica que la descripcion de la pregunta sea test question
-        self.assertEquals(str(v.question),"test question")
-        #Verifica que la primera opcion es option1 (2)
-        self.assertEquals(str(v.question.options.all()[0]),"option 1 (2)")
+        # Verifica que el nombre de la votacion es test voting
+        self.assertEquals(str(v), "test voting")
+        # Verifica que la descripcion de la pregunta sea test question
+        self.assertEquals(str(v.question), "test question")
+        # Verifica que la primera opcion es option1 (2)
+        self.assertEquals(str(v.question.options.all()[0]), "option 1 (2)")
 
     def test_create_voting_API(self):
         self.login()
         data = {
-            'name': 'Example',
-            'desc': 'Description example',
-            'question': 'I want a ',
-            'question_opt': ['cat', 'dog', 'horse']
+            "name": "Example",
+            "desc": "Description example",
+            "question": "I want a ",
+            "question_type": "DEFAULT",
+            "question_opt": ["cat", "dog", "horse"],
         }
 
-        response = self.client.post('/voting/', data, format='json')
+        response = self.client.post("/voting/", data, format="json")
         self.assertEqual(response.status_code, 201)
 
-        voting = Voting.objects.get(name='Example')
-        self.assertEqual(voting.desc, 'Description example')
-        
+        voting = Voting.objects.get(name="Example")
+        self.assertEqual(voting.desc, "Description example")
+
 
 class LogInSuccessTests(StaticLiveServerTestCase):
-
     def setUp(self):
-        #Load base test functionality for decide
+        # Load base test functionality for decide
         self.base = BaseTestCase()
         self.base.setUp()
 
@@ -263,7 +266,7 @@ class LogInSuccessTests(StaticLiveServerTestCase):
         self.base.tearDown()
 
     def successLogIn(self):
-        self.cleaner.get(self.live_server_url+"/admin/login/?next=/admin/")
+        self.cleaner.get(self.live_server_url + "/admin/login/?next=/admin/")
         self.cleaner.set_window_size(1280, 720)
 
         self.cleaner.find_element(By.ID, "id_username").click()
@@ -273,12 +276,12 @@ class LogInSuccessTests(StaticLiveServerTestCase):
         self.cleaner.find_element(By.ID, "id_password").send_keys("decide")
 
         self.cleaner.find_element(By.ID, "id_password").send_keys("Keys.ENTER")
-        self.assertTrue(self.cleaner.current_url == self.live_server_url+"/admin/")
+        self.assertTrue(self.cleaner.current_url == self.live_server_url + "/admin/")
+
 
 class LogInErrorTests(StaticLiveServerTestCase):
-
     def setUp(self):
-        #Load base test functionality for decide
+        # Load base test functionality for decide
         self.base = BaseTestCase()
         self.base.setUp()
 
@@ -295,9 +298,9 @@ class LogInErrorTests(StaticLiveServerTestCase):
         self.base.tearDown()
 
     def usernameWrongLogIn(self):
-        self.cleaner.get(self.live_server_url+"/admin/login/?next=/admin/")
+        self.cleaner.get(self.live_server_url + "/admin/login/?next=/admin/")
         self.cleaner.set_window_size(1280, 720)
-        
+
         self.cleaner.find_element(By.ID, "id_username").click()
         self.cleaner.find_element(By.ID, "id_username").send_keys("usuarioNoExistente")
 
@@ -306,10 +309,15 @@ class LogInErrorTests(StaticLiveServerTestCase):
 
         self.cleaner.find_element(By.ID, "id_password").send_keys("Keys.ENTER")
 
-        self.assertTrue(self.cleaner.find_element_by_xpath('/html/body/div/div[2]/div/div[1]/p').text == 'Please enter the correct username and password for a staff account. Note that both fields may be case-sensitive.')
+        self.assertTrue(
+            self.cleaner.find_element_by_xpath(
+                "/html/body/div/div[2]/div/div[1]/p"
+            ).text
+            == "Please enter the correct username and password for a staff account. Note that both fields may be case-sensitive."
+        )
 
     def passwordWrongLogIn(self):
-        self.cleaner.get(self.live_server_url+"/admin/login/?next=/admin/")
+        self.cleaner.get(self.live_server_url + "/admin/login/?next=/admin/")
         self.cleaner.set_window_size(1280, 720)
 
         self.cleaner.find_element(By.ID, "id_username").click()
@@ -320,12 +328,17 @@ class LogInErrorTests(StaticLiveServerTestCase):
 
         self.cleaner.find_element(By.ID, "id_password").send_keys("Keys.ENTER")
 
-        self.assertTrue(self.cleaner.find_element_by_xpath('/html/body/div/div[2]/div/div[1]/p').text == 'Please enter the correct username and password for a staff account. Note that both fields may be case-sensitive.')
+        self.assertTrue(
+            self.cleaner.find_element_by_xpath(
+                "/html/body/div/div[2]/div/div[1]/p"
+            ).text
+            == "Please enter the correct username and password for a staff account. Note that both fields may be case-sensitive."
+        )
+
 
 class QuestionsTests(StaticLiveServerTestCase):
-
     def setUp(self):
-        #Load base test functionality for decide
+        # Load base test functionality for decide
         self.base = BaseTestCase()
         self.base.setUp()
 
@@ -342,7 +355,7 @@ class QuestionsTests(StaticLiveServerTestCase):
         self.base.tearDown()
 
     def createQuestionSuccess(self):
-        self.cleaner.get(self.live_server_url+"/admin/login/?next=/admin/")
+        self.cleaner.get(self.live_server_url + "/admin/login/?next=/admin/")
         self.cleaner.set_window_size(1280, 720)
 
         self.cleaner.find_element(By.ID, "id_username").click()
@@ -353,24 +366,26 @@ class QuestionsTests(StaticLiveServerTestCase):
 
         self.cleaner.find_element(By.ID, "id_password").send_keys("Keys.ENTER")
 
-        self.cleaner.get(self.live_server_url+"/admin/voting/question/add/")
-        
+        self.cleaner.get(self.live_server_url + "/admin/voting/question/add/")
+
         self.cleaner.find_element(By.ID, "id_desc").click()
-        self.cleaner.find_element(By.ID, "id_desc").send_keys('Test')
+        self.cleaner.find_element(By.ID, "id_desc").send_keys("Test")
         self.cleaner.find_element(By.ID, "id_options-0-number").click()
-        self.cleaner.find_element(By.ID, "id_options-0-number").send_keys('1')
+        self.cleaner.find_element(By.ID, "id_options-0-number").send_keys("1")
         self.cleaner.find_element(By.ID, "id_options-0-option").click()
-        self.cleaner.find_element(By.ID, "id_options-0-option").send_keys('test1')
+        self.cleaner.find_element(By.ID, "id_options-0-option").send_keys("test1")
         self.cleaner.find_element(By.ID, "id_options-1-number").click()
-        self.cleaner.find_element(By.ID, "id_options-1-number").send_keys('2')
+        self.cleaner.find_element(By.ID, "id_options-1-number").send_keys("2")
         self.cleaner.find_element(By.ID, "id_options-1-option").click()
-        self.cleaner.find_element(By.ID, "id_options-1-option").send_keys('test2')
+        self.cleaner.find_element(By.ID, "id_options-1-option").send_keys("test2")
         self.cleaner.find_element(By.NAME, "_save").click()
 
-        self.assertTrue(self.cleaner.current_url == self.live_server_url+"/admin/voting/question/")
+        self.assertTrue(
+            self.cleaner.current_url == self.live_server_url + "/admin/voting/question/"
+        )
 
     def createCensusEmptyError(self):
-        self.cleaner.get(self.live_server_url+"/admin/login/?next=/admin/")
+        self.cleaner.get(self.live_server_url + "/admin/login/?next=/admin/")
         self.cleaner.set_window_size(1280, 720)
 
         self.cleaner.find_element(By.ID, "id_username").click()
@@ -381,146 +396,160 @@ class QuestionsTests(StaticLiveServerTestCase):
 
         self.cleaner.find_element(By.ID, "id_password").send_keys("Keys.ENTER")
 
-        self.cleaner.get(self.live_server_url+"/admin/voting/question/add/")
+        self.cleaner.get(self.live_server_url + "/admin/voting/question/add/")
 
         self.cleaner.find_element(By.NAME, "_save").click()
 
-        self.assertTrue(self.cleaner.find_element_by_xpath('/html/body/div/div[3]/div/div[1]/div/form/div/p').text == 'Please correct the errors below.')
-        self.assertTrue(self.cleaner.current_url == self.live_server_url+"/admin/voting/question/add/")
-        
-        
+        self.assertTrue(
+            self.cleaner.find_element_by_xpath(
+                "/html/body/div/div[3]/div/div[1]/div/form/div/p"
+            ).text
+            == "Please correct the errors below."
+        )
+        self.assertTrue(
+            self.cleaner.current_url
+            == self.live_server_url + "/admin/voting/question/add/"
+        )
+
+
 class VotingModelTestCase(BaseTestCase):
-    
     def setUp(self):
-        q = Question(desc='Descripcion')
+        q = Question(desc="Descripcion")
         q.save()
-        
-        opt1 = QuestionOption(question=q, option='opcion 1')
+
+        opt1 = QuestionOption(question=q, option="opcion 1")
         opt1.save()
-        opt1 = QuestionOption(question=q, option='opcion 2')
+        opt1 = QuestionOption(question=q, option="opcion 2")
         opt1.save()
 
-        self.v = Voting(name='Votacion', question=q)
+        self.v = Voting(name="Votacion", question=q)
         self.v.save()
 
-class QuestionTestCase(BaseTestCase):
 
+class QuestionTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
+        q = Question(desc="Descripcion")
+        q.save()
+
+        opt1 = QuestionOption(question=q, option="opcion 1")
+        opt1.save()
+        opt1 = QuestionOption(question=q, option="opcion 2")
+        opt1.save()
+
+        self.v = Voting(name="Votacion", question=q)
+        self.v.save()
 
     def tearDown(self):
         super().tearDown()
         self.v = None
+        Voting.objects.get(name="Votacion").delete()
 
     def testExist(self):
-        v=Voting.objects.get(name='Votacion')
+        v = Voting.objects.get(name="Votacion")
         self.assertEquals(v.question.options.all()[0].option, "opcion 1")
 
     def test_create_question(self):
-        q = Question(desc='test question')
+        q = Question(desc="test question")
         q.save()
-        self.assertEqual(q.desc, 'test question')
-        self.assertEqual(q.question_type, 'DEFAULT')
+        self.assertEqual(q.desc, "test question")
+        self.assertEqual(q.question_type, "DEFAULT")
         self.assertEqual(q.options.count(), 0)
 
     def test_create_question_yesno_from_api(self):
-        data = {'desc': 'test question', 'question_type': 'YESNO'}
-        response = self.client.post('/voting/question/', data, format='json')
+        data = {"desc": "test question", "question_type": "YESNO"}
+        response = self.client.post("/voting/question/", data, format="json")
         self.assertEqual(response.status_code, 401)
 
         # login with user no admin
-        self.login(user='noadmin')
-        response = self.client.post('/voting/question/', data, format='json')
+        self.login(user="noadmin")
+        response = self.client.post("/voting/question/", data, format="json")
         self.assertEqual(response.status_code, 403)
 
         # login with user admin
         self.login()
-        response = self.client.post('/voting/question/', data, format='json')
+        response = self.client.post("/voting/question/", data, format="json")
         self.assertEqual(response.status_code, 400)
 
-        data = {
-            'desc': 'Description example',
-            'question_type': 'YESNO',
-            'options': []
-        }
+        data = {"desc": "Description example", "question_type": "YESNO", "options": []}
 
-        response = self.client.post('/voting/question/', data, format='json')
+        response = self.client.post("/voting/question/", data, format="json")
         self.assertEqual(response.status_code, 201)
 
 
-        
 class VotingRankingTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
-    
+
     def tearDown(self):
         return super().tearDown()
-    
+
     def create_ranking_voting(self):
-        q = Question(desc='test ranking voting', question_type='RANKING')
+        q = Question(desc="test ranking voting", question_type="RANKING")
         q.save()
-        for i in range(1,4):
-            opt = QuestionOption(question=q, option='option {}'.format(i))
+        for i in range(1, 4):
+            opt = QuestionOption(question=q, option="option {}".format(i))
             opt.save()
-        v = Voting(name='test ranking voting', question=q)
+        v = Voting(name="test ranking voting", question=q)
         v.save()
-        
-        a, _ = Auth.objects.get_or_create(url=settings.BASEURL,
-                                            defaults = {'me': True, 'name': 'test auth'})
+
+        a, _ = Auth.objects.get_or_create(
+            url=settings.BASEURL, defaults={"me": True, "name": "test auth"}
+        )
         a.save()
         v.auths.add(a)
         return v
-        
+
     def create_voters(self, v):
         for i in range(10):
-            u, _ = User.objects.get_or_create(username='testRankingVoter{}'.format(i))
+            u, _ = User.objects.get_or_create(username="testRankingVoter{}".format(i))
             u.is_active = True
             u.save()
             c = Census(voter_id=u.id, voting_id=v.id)
             c.save()
-            
+
     def get_or_create_user(self, pk):
         user, _ = User.objects.get_or_create(pk=pk)
-        user.username = 'user{}'.format(pk)
-        user.set_password('qwerty')
+        user.username = "user{}".format(pk)
+        user.set_password("qwerty")
         user.save()
         return user
-            
+
     def encrypt_msg(self, msg, v, bits=settings.KEYBITS):
         pk = v.pub_key
         p, g, y = (pk.p, pk.g, pk.y)
         k = MixCrypt(bits=bits)
         k.k = ElGamal.construct((p, g, y))
         return k.encrypt(msg)
-            
+
     def store_votes(self, v):
         import random
         from Crypto.Util.number import bytes_to_long
-        
+
         voters = list(Census.objects.filter(voting_id=v.id))
         voter = voters.pop()
         ranking_list = list(range(1, len(v.question.options.all()) + 1))
-        
+
         clear = {}
         for voter in voters:
             random.shuffle(ranking_list)
-            key = int(''.join(map(str, ranking_list)))
-            
+            key = int("".join(map(str, ranking_list)))
+
             if key in clear:
                 clear[key] += 1
             else:
                 clear[key] = 1
-                
+
             message = int(key)
             a, b = self.encrypt_msg(message, v)
             data = {
-                'voting': v.id,
-                'voter': voter.voter_id,
-                'vote': { 'a': a, 'b': b },
+                "voting": v.id,
+                "voter": voter.voter_id,
+                "vote": {"a": a, "b": b},
             }
             user = self.get_or_create_user(voter.voter_id)
             self.login(user=user.username)
-            mods.post('store', json=data)
+            mods.post("store", json=data)
 
         return clear
 
@@ -539,15 +568,17 @@ class VotingRankingTestCase(BaseTestCase):
 
         tally = v.tally
         tally.sort()
-        tally = {k: len(list(x)) for k, x in itertools.groupby(tally)}        
+        tally = {k: len(list(x)) for k, x in itertools.groupby(tally)}
 
         ranking = clear.keys()
         for order in ranking:
             self.assertEqual(tally.get(order, 0), clear.get(order, 0))
 
-        ranking_selected = str(max(tally, key=tally.get))
-        postp = list(map(lambda o : str(o['number'] - 1), sorted(v.postproc, key=lambda p : p['postproc'])))
-        postp_selected = ''.join(postp)
-        self.assertEqual(ranking_selected, postp_selected)
-
-
+        postp = list(
+            map(
+                lambda o: str(o["number"] - 1),
+                sorted(v.postproc, key=lambda p: p["postproc"]),
+            )
+        )
+        postp_selected = int("".join(postp))
+        self.assertIn(postp_selected, list(tally.keys()))


### PR DESCRIPTION
Soluciona los problemas con los tests del módulo voting. En concreto:

- _testExists_: comprueba si existe una votación. Fallaba porque no se había creado dicha votación.

- _test_create_voting_API_ y _test_create_voting_from_api_: crean una votación mediante el uso de la API desarrollada por @silvglad. El problema consisitía en que al crearse se hace una comprobación de todos los campos de request.data de la petición. Si falta algún campo no crea la votación. Parece ser que se había actualizado el código de la vista, pero no los tests correspondientes.

- _test_ranking_voting_: crea una votación de tipo ranking. El problema consistía en que no hallaba de forma correcta el valor del ranking más votado. Por ello, al comparar, el postprocesado y el tally no daban el mismo resultado.