### PR TITLE
fix: soluciona correcta ordenación del ranking

### DIFF
--- a/decide/voting/models.py
+++ b/decide/voting/models.py
@@ -9,20 +9,24 @@ from base.models import Auth, Key
 
 class Question(models.Model):
     desc = models.TextField()
-    
-    class QuestionType (models.TextChoices):
-        DEFAULT = 'DEFAULT', 'Default'
-        YESNO = 'YESNO', 'Yes/No'
-        RANKING = 'RANKING', 'Ranking'
 
-    question_type = models.CharField(max_length=20, choices=QuestionType.choices, default=QuestionType.DEFAULT)
-    
+    class QuestionType(models.TextChoices):
+        DEFAULT = "DEFAULT", "Default"
+        YESNO = "YESNO", "Yes/No"
+        RANKING = "RANKING", "Ranking"
+
+    question_type = models.CharField(
+        max_length=20, choices=QuestionType.choices, default=QuestionType.DEFAULT
+    )
+
     def __str__(self):
         return self.desc
 
 
 class QuestionOption(models.Model):
-    question = models.ForeignKey(Question, related_name='options', on_delete=models.CASCADE)
+    question = models.ForeignKey(
+        Question, related_name="options", on_delete=models.CASCADE
+    )
     number = models.PositiveIntegerField(blank=True, null=True)
     option = models.TextField()
 
@@ -32,19 +36,23 @@ class QuestionOption(models.Model):
         return super().save()
 
     def __str__(self):
-        return '{} ({})'.format(self.option, self.number)
+        return "{} ({})".format(self.option, self.number)
 
 
 class Voting(models.Model):
     name = models.CharField(max_length=200)
     desc = models.TextField(blank=True, null=True)
-    question = models.ForeignKey(Question, related_name='voting', on_delete=models.CASCADE)
+    question = models.ForeignKey(
+        Question, related_name="voting", on_delete=models.CASCADE
+    )
 
     start_date = models.DateTimeField(blank=True, null=True)
     end_date = models.DateTimeField(blank=True, null=True)
 
-    pub_key = models.OneToOneField(Key, related_name='voting', blank=True, null=True, on_delete=models.SET_NULL)
-    auths = models.ManyToManyField(Auth, related_name='votings')
+    pub_key = models.OneToOneField(
+        Key, related_name="voting", blank=True, null=True, on_delete=models.SET_NULL
+    )
+    auths = models.ManyToManyField(Auth, related_name="votings")
 
     tally = JSONField(blank=True, null=True)
     postproc = JSONField(blank=True, null=True)
@@ -56,34 +64,36 @@ class Voting(models.Model):
         auth = self.auths.first()
         data = {
             "voting": self.id,
-            "auths": [ {"name": a.name, "url": a.url} for a in self.auths.all() ],
+            "auths": [{"name": a.name, "url": a.url} for a in self.auths.all()],
         }
-        key = mods.post('mixnet', baseurl=auth.url, json=data)
+        key = mods.post("mixnet", baseurl=auth.url, json=data)
         pk = Key(p=key["p"], g=key["g"], y=key["y"])
         pk.save()
         self.pub_key = pk
         self.save()
 
-    def get_votes(self, token=''):
+    def get_votes(self, token=""):
         # gettings votes from store
-        votes = mods.get('store', params={'voting_id': self.id}, HTTP_AUTHORIZATION='Token ' + token)
+        votes = mods.get(
+            "store", params={"voting_id": self.id}, HTTP_AUTHORIZATION="Token " + token
+        )
         # anon votes
         votes_format = []
         vote_list = []
         for vote in votes:
             for info in vote:
-                if info == 'a':
+                if info == "a":
                     votes_format.append(vote[info])
-                if info == 'b':
+                if info == "b":
                     votes_format.append(vote[info])
             vote_list.append(votes_format)
             votes_format = []
         return vote_list
 
-    def tally_votes(self, token=''):
-        '''
+    def tally_votes(self, token=""):
+        """
         The tally is a shuffle and then a decrypt
-        '''
+        """
 
         votes = self.get_votes(token)
 
@@ -93,17 +103,27 @@ class Voting(models.Model):
         auths = [{"name": a.name, "url": a.url} for a in self.auths.all()]
 
         # first, we do the shuffle
-        data = { "msgs": votes }
-        response = mods.post('mixnet', entry_point=shuffle_url, baseurl=auth.url, json=data,
-                response=True)
+        data = {"msgs": votes}
+        response = mods.post(
+            "mixnet",
+            entry_point=shuffle_url,
+            baseurl=auth.url,
+            json=data,
+            response=True,
+        )
         if response.status_code != 200:
             # TODO: manage error
             pass
 
         # then, we can decrypt that
         data = {"msgs": response.json()}
-        response = mods.post('mixnet', entry_point=decrypt_url, baseurl=auth.url, json=data,
-                response=True)
+        response = mods.post(
+            "mixnet",
+            entry_point=decrypt_url,
+            baseurl=auth.url,
+            json=data,
+            response=True,
+        )
 
         if response.status_code != 200:
             # TODO: manage error
@@ -117,35 +137,36 @@ class Voting(models.Model):
     def do_postproc(self):
         tally = self.tally
         options = self.question.options.all()
+        options = sorted(options, key=lambda o: o.number)
 
         opts = []
-        if self.question.question_type == 'RANKING':
+        if self.question.question_type == "RANKING":
             votes = 0
             if isinstance(tally, list):
                 mode = 0
-                for i,v in enumerate(tally):
+                for i, v in enumerate(tally):
                     mode = i if tally.count(v) > mode else mode
                 votes = [int(digit) for digit in str(tally[mode])]
-                for i,opt in enumerate(options):
-                    opts.append({
-                        'option': opt.option,
-                        'number': opt.number,
-                        'votes': votes[i]
-                })
+                for i, opt in enumerate(options):
+                    opts.append(
+                        {
+                            "option": opt.option,
+                            "number": opt.number,
+                            "votes": votes.index(opt.number - 1),
+                        }
+                    )
         else:
             for opt in options:
                 if isinstance(tally, list):
                     votes = tally.count(opt.number)
                 else:
                     votes = 0
-                opts.append({
-                    'option': opt.option,
-                    'number': opt.number,
-                    'votes': votes
-                })
+                opts.append(
+                    {"option": opt.option, "number": opt.number, "votes": votes}
+                )
 
-        data = { 'type': 'IDENTITY', 'options': opts }
-        postp = mods.post('postproc', json=data)
+        data = {"type": "IDENTITY", "options": opts}
+        postp = mods.post("postproc", json=data)
 
         self.postproc = postp
         self.save()


### PR DESCRIPTION
Problema con la ordenación de las opciones de una votación ranking.

Al hacer un retrieve de las opciones de una votación de la base de datos, estas no tienen por qué venir ordenadas en función de su número de identificación. Es decir, que sea la opción con id=1 no significa que vaya a ser la primera en la lista de opciones. Por tanto, antes de hacer cualquier postprocesado, hay que reordenar la lista en función de los id's de las opciones:

![image](https://github.com/3ralon/decide-single-zambrano/assets/128732971/a47e2d01-1069-474a-9d22-451d867b3aa3)

Esto estaba dando problemas a la hora de ordenar las opciones en función del orden más votado. Hacía que no siempre saliese el orden esperado.

Y ya luego, se puede seguir procesando la votación como antes.