### PR TITLE
fix: soluciona comparación entre tally y postproc #56

### DIFF
--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -572,7 +572,7 @@ class VotingRankingTestCase(BaseTestCase):
 
         ranking = clear.keys()
         for order in ranking:
-            self.assertEqual(tally.get(order, 0), clear.get(order, 0))
+            self.assertEquals(tally.get(order, 0), clear.get(order, 0))
 
         postp = list(
             map(
@@ -581,4 +581,11 @@ class VotingRankingTestCase(BaseTestCase):
             )
         )
         postp_selected = int("".join(postp))
+
         self.assertIn(postp_selected, list(tally.keys()))
+
+        tally_values = list(tally.values())
+        votes_postp_selected = tally[postp_selected]
+
+        for v in tally_values:
+            self.assertGreaterEqual(votes_postp_selected, v)


### PR DESCRIPTION
Debido a la ordenación de las opciones de una votación ranking a veces se obtenían mal los resultados. Se ha arreglado la ordenación en el modelo y esta PR arregla la comprobación en los tests en _/voting/tests.py_.

Relacionado con el issue #58 