### PR TITLE
Refactor: Limpieza del código de Census Exportation

### DIFF
--- a/decide/census/templates/export_csv.html
+++ b/decide/census/templates/export_csv.html
@@ -34,18 +34,30 @@
         font-size: 35px;
         color:midnightblue;
         }
+    #formulario-csv {
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+    }
+
     </style>
 </head>
 <body>
-    
-    <a href="{% url 'export-all-census' %}" class="elemento-bloque">Exportar todas las votaciones a CSV</a>
-    <form action="{% url 'export-to-csv' %}" method="GET" class="elemento-bloque">
-        <label for="voting_id">Introduce la ID de votación:</label>
-        <input type="number" id="voting_id" name="voting_id" required>
-        <input type="submit" value="Exportar a votación a CSV">
-    </form>
-       
     <div class="top-right">DECIDE</div>
+    <section id="formulario-csv">
+        <form action="{% url 'export-all-census' %}" method="POST" class="elemento-bloque">
+            {% csrf_token %}
+            <input type="submit" value="Exportar CSV completo">
+        </form>
+
+        <form action="{% url 'export-to-csv' %}" method="POST" class="elemento-bloque">
+            {% csrf_token %}
+            <label for="voting_id">Introduce la ID de votación:</label>
+            <input type="number" id="voting_id" min="0" max="{{ votaciones }}" name="voting_id" required>
+            <input type="submit" value="Exportar a votación a CSV">
+        </form>
+    </section>
 
 </body>
+
 </html>

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -37,7 +37,7 @@ class CensusExportationToCSV(TemplateView):
         return context
 
     def get(self, request, *args, **kwargs):
-        if request.user.is_authenticated == None or request.user.is_authenticated is False:
+        if request.user.is_authenticated is None or request.user.is_authenticated is False:
             return HttpResponseForbidden('Debes estar logueado para poder descargar el csv')
         elif not request.user.is_superuser:
             return HttpResponseForbidden('Solo los superuser pueden descargar los datos del censo')

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -1,3 +1,4 @@
+from typing import Any
 from django.db.utils import IntegrityError
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import generics, status
@@ -10,103 +11,55 @@ from rest_framework.status import (
         HTTP_204_NO_CONTENT as ST_204,
         HTTP_400_BAD_REQUEST as ST_400,
         HTTP_401_UNAUTHORIZED as ST_401,
+        HTTP_403_FORBIDDEN as ST_403,
         HTTP_409_CONFLICT as ST_409)
 import csv
 from django.views import View
 from base.perms import UserIsStaff
 from .models import Census
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseForbidden
 from django.contrib.auth.decorators import user_passes_test
 from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponse
 import csv
 from .models import Census
+from voting.models import Voting
+from django.views.generic.base import TemplateView
 
 
-class CensusExportationToCSV(View):     
-    
+class CensusExportationToCSV(TemplateView):
+    template_name = "export_csv.html"
+
+    def get_context_data(self, **kwargs: Any):
+        votaciones = Voting.objects.all().count()
+        context = super().get_context_data(**kwargs)
+        context['votaciones'] = votaciones
+        return context
+
     def get(self, request, *args, **kwargs):
-        voting_id = kwargs.get('voting_id')
-        if voting_id is not None:
-            census = Census.objects.filter(voting_id=voting_id)
-            filename = f"censo_{voting_id}.csv"
-        else:
-            census = Census.objects.all()
-            filename = "CensoCompleto.csv"
+        if request.user.is_authenticated == None or request.user.is_authenticated == False:
+            return HttpResponseForbidden('Debes estar logueado para poder descargar el csv')
+        elif not request.user.is_superuser:
+            return HttpResponseForbidden('Solo los superuser pueden descargar los datos del censo')
+        return super().get(request, *args, **kwargs)
 
+    def post(self, request, *args, **kwargs):
         if not request.user.is_superuser:
-            return HttpResponse("Only superusers can download census data")
-
+            return HttpResponseForbidden('Solo los superuser pueden descargar los datos del censo')
+        voting_id = request.POST.get('voting_id') or kwargs.get('voting_id')
+        filename = f"Censo_{voting_id}.csv" if voting_id else "CensoCompleto.csv"
+        census = Census.objects.filter(voting_id=voting_id) if voting_id else Census.objects.all()
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = f'attachment; filename="{filename}"'
-
-        writer = csv.writer(response)
-        writer.writerow(['Voting', 'Voter'])
-        for profile in census:
-            writer.writerow([profile.voting_id, profile.voter_id])
-        return response
-
-    def export_all_census(self, request):
-        if not request.user.is_superuser:
-            return HttpResponse("Only superusers can download census data")
-        census = Census.objects.all()
-        response = HttpResponse(
-        content_type = 'text/csv',
-        headers = {
-            "Content-Disposition": 'attachment; filename="CensoCompleto.csv"'
-            }
-        )
-        writer = csv.writer(response)
-        writer.writerow(['Voting','Voter'])
-        profile_fields = census.values_list('voting_id', 'voter_id')
-        for profile in profile_fields:
-            writer.writerow(profile)
-        return response 
-
-    def export_voting_to_csv(self, request, voting_id):
-        if not request.user.is_superuser:
-            return HttpResponse("Only superusers can download census data")
-
-        census = Census.objects.filter(voting_id=voting_id)  
-        response = HttpResponse(
-        content_type='text/csv',
-        headers={
-            "Content-Disposition": 'attachment; filename="censo.csv"'
-            } )
         writer = csv.writer(response)
         writer.writerow(['Voting', 'Voter'])
         for profile in census:
             writer.writerow([profile.voting_id, profile.voter_id])
         return response
     
-    def export_to_csv(self, request):
-        if not request.user.is_superuser:
-            return HttpResponse("Only superusers can download census data")
-
-        if request.method == 'GET':
-            voting_id = request.GET.get('voting_id')
-            if voting_id is not None:
-                census = Census.objects.filter(voting_id=voting_id)
-                response = HttpResponse(
-                    content_type='text/csv',
-                    headers={
-                        "Content-Disposition": 'attachment; filename="censo.csv"'
-                    }
-                )
-                writer = csv.writer(response)
-                writer.writerow(['Voting', 'Voter'])
-                for profile in census:
-                    writer.writerow([profile.voting_id, profile.voter_id])
-                return response
-            else:
-                return HttpResponse("No se proporcionó una ID de votación válida")
-        else:
-            return HttpResponse("Método de solicitud no válido")
 
     
 class CensusCreate(generics.ListCreateAPIView):
-    
-    permission_classes = (UserIsStaff,)
     
     def create(self, request, *args, **kwargs):
         voting_id = request.data.get('voting_id')
@@ -123,7 +76,6 @@ class CensusCreate(generics.ListCreateAPIView):
         voting_id = request.GET.get('voting_id')
         voters = Census.objects.filter(voting_id=voting_id).values_list('voter_id', flat=True)
         return Response({'voters': voters})
-
 
 class CensusDetail(generics.RetrieveDestroyAPIView):
 

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -37,7 +37,7 @@ class CensusExportationToCSV(TemplateView):
         return context
 
     def get(self, request, *args, **kwargs):
-        if request.user.is_authenticated == None or request.user.is_authenticated == False:
+        if request.user.is_authenticated == None or request.user.is_authenticated is False:
             return HttpResponseForbidden('Debes estar logueado para poder descargar el csv')
         elif not request.user.is_superuser:
             return HttpResponseForbidden('Solo los superuser pueden descargar los datos del censo')
@@ -58,8 +58,10 @@ class CensusExportationToCSV(TemplateView):
         return response
     
 
-    
+
 class CensusCreate(generics.ListCreateAPIView):
+    
+    permission_classes = (UserIsStaff,)
     
     def create(self, request, *args, **kwargs):
         voting_id = request.data.get('voting_id')
@@ -76,6 +78,7 @@ class CensusCreate(generics.ListCreateAPIView):
         voting_id = request.GET.get('voting_id')
         voters = Census.objects.filter(voting_id=voting_id).values_list('voter_id', flat=True)
         return Response({'voters': voters})
+
 
 class CensusDetail(generics.RetrieveDestroyAPIView):
 


### PR DESCRIPTION
Se ha puesto el código de manera más correcta y organizada, pues habían métodos que hacían lo mismo y no terminaba de funcionar correctamente la implementación que había.