### PR TITLE
Fix: Duplicado de Censo

### DIFF
--- a/decide/voting/views.py
+++ b/decide/voting/views.py
@@ -248,8 +248,9 @@ class CensusVoting(TemplateView):
             if form.is_valid():
                 users = form.cleaned_data["user"]
                 for user in users:
-                    census = Census(voting_id=voting_id, voter_id=user.id)
-                    census.save()
+                    if not Census.objects.filter(voting_id=voting_id, voter_id=user.id).exists():
+                        census = Census(voting_id=voting_id, voter_id=user.id)
+                        census.save()
                 return redirect("voting_list")
             return render(request, "census_voting.html", {"form": form})
         else:


### PR DESCRIPTION
Desde el panel de administración de la homepage, al intentar añadir al censo de una votación a un mismo usuario dos veces, salta un error de duplicado.

Se ha añadido la comprobación en la vista para que no ocurra el error. Cierra #131 